### PR TITLE
on_messageで受け取った後にコマンドとして処理するように修正

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -77,6 +77,8 @@ async def on_message(ctx):
     if ctx.author.bot:
         return
 
+    await bot.process_commands(ctx)
+
 
 # https://techblog.cartaholdings.co.jp/entry/archives/6412
 # チャンネル入退室時の通知処理


### PR DESCRIPTION
思うにこのコミット( aefd66d29cbbb7e9aab00992623da3ad70546627 )で通常のコマンドを受け付けなくなっていたのではないかと思う 

該当コミットの修正について、各cog内のlistenerとして生やす `on_message` と、botに直接生やす `on_message` は発火するタイミングが違う様子でした。

前者の場合は各cogのコマンドなどが処理された後にcog内の `on_message` が実行される様子ですが、後者の場合は `on_message` の中で `process_commands` を呼ばない限りは各cog(や直接生やしているタイプも含めた)コマンドが一切実行されないようでした。

今回は `on_message` の中で `process_commands` を呼ぶように変更しています。